### PR TITLE
fix(build-tools) Build tools failed on sdk update filter

### DIFF
--- a/manifests/build_tools.pp
+++ b/manifests/build_tools.pp
@@ -2,13 +2,15 @@
 #
 # Usage:
 #
-#     android::build_tools { '18.1.1': }
+#     android::build_tools { 'build-tools-18.1.1': }
 define android::build_tools(
   $ensure    = present,
   $version   = $name
 ) {
-  android::definition{ $version:
+  $version_number = regsubst($version, 'build-tools-', '')
+
+  android::definition{ $name:
     ensure    => $ensure,
-    dest_path => "build-tools/${version}",
+    dest_path => "build-tools/${version_number}",
   }
 }


### PR DESCRIPTION
I tried with  `android::build_tools { '19.1.0': }`

But I get this error

```
Error: /opt/boxen/homebrew/opt/android-sdk/bin/android update sdk --all --no-ui --filter 19.1 returned 1 instead of one of [0]
```

The it worked with this..

``` ruby
android::build_tools { 'build-tools-19.1.0': }
```

@aafwu00 can you take a look to this PR
